### PR TITLE
Add the ability to ignore parameters this comes in handy when you have code sending times as part of the query string.

### DIFF
--- a/JustFakeIt.Tests/FakeServerScenarios.cs
+++ b/JustFakeIt.Tests/FakeServerScenarios.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Specialized;
 using System.Net;
 using System.Net.Http;
 using FluentAssertions;
@@ -305,6 +304,29 @@ namespace JustFakeIt.Tests
                 var result = t.Result;
 
                 result.StatusCode.Should().Be(HttpStatusCode.Created);
+            }
+        }
+
+
+        [Fact]
+        public void FakeServer_IgnoredParameter_Returns200()
+        {
+            var expectedResult = new { ResourceId = 1234 };
+            const string baseAddress = "http://localhost:12354";
+
+            const string fakeurl = "/some-resource/{ignore}/some-resource?date={ignore}&type={ignore}";
+            const string actualurl = "/some-resource/1234/some-resource?date=2015-02-06T09:52:10&type=1";
+
+            using (var fakeServer = new FakeServer(12354))
+            {
+                fakeServer.Expect.Get(fakeurl).Returns(HttpStatusCode.Accepted, expectedResult);
+                fakeServer.Start();
+
+                var t = new HttpClient().GetAsync(new Uri(baseAddress + actualurl));
+                t.Wait();
+                var result = t.Result;
+
+                result.StatusCode.Should().Be(HttpStatusCode.Accepted);
             }
         }
 

--- a/JustFakeIt/ExpectationExtensions.cs
+++ b/JustFakeIt/ExpectationExtensions.cs
@@ -1,13 +1,41 @@
 ﻿using System;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace JustFakeIt
 {
     public static class ExpectationExtensions
     {
+        public const string IgnoreParameter = "{ignore}";
+
         public static bool MatchesActualPath(this HttpRequestExpectation expected, string actualPath)
         {
-            return actualPath.Equals(expected.Url);
+            var newPath = MatchIgnoredParameters(expected, actualPath);
+            return newPath.Equals(expected.Url);
+        }
+
+        private static string MatchIgnoredParameters(HttpRequestExpectation expected, string actualPath)
+        {
+            if (expected.Url.IndexOf(IgnoreParameter, StringComparison.Ordinal) == -1) return actualPath;
+
+            var segments = Regex.Split(expected.Url, IgnoreParameter);
+            for (var i = 0; i < segments.Length; i++)
+            {
+                if (segments[i] == "") continue;
+                var segmentEnd = actualPath.IndexOf(segments[i], StringComparison.Ordinal) + segments[i].Length;
+                var nextSegmentStart = actualPath.Length;
+                if (segments.Length != i + 1)
+                {
+                    if (segments[i + 1] != "")
+                    {
+                        nextSegmentStart = actualPath.IndexOf(segments[i + 1], StringComparison.Ordinal);
+                    }
+                }
+
+                actualPath = actualPath.Replace(actualPath.Substring(segmentEnd, nextSegmentStart - segmentEnd),
+                    IgnoreParameter);
+            }
+            return actualPath;
         }
 
         public static bool MatchesActualHttpMethod(this HttpRequestExpectation expected, string actualHttpMethod)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ public void FakeServer_ExpectGetReturnsString_ResponseMatchesExpectation()
 }
 ```
 
+Ignore parameters by replacing the value with "{ignore}"
+
+```
+ var fakeurl = "/some-resource/{ignore}/some-resource?date={ignore}&type={ignore}";
+ fakeServer.Expect.Get(fakeurl).Returns(HttpStatusCode.Accepted, expectedResult);
+```
+
 ## Contributing
 
 If you find a bug, have a feature request or even want to contribute an enhancement or fix, please follow the [contributing guidelines](CONTRIBUTING.md) included in the repository.


### PR DESCRIPTION
![selfie-0](http://i.imgur.com/1SMa10i.png)
