### PR TITLE
Greedy mode

### DIFF
--- a/JustFakeIt/Expect.cs
+++ b/JustFakeIt/Expect.cs
@@ -5,52 +5,35 @@ namespace JustFakeIt
 {
     public class Expect
     {
-        TimeSpan _responseTime = TimeSpan.Zero;
         internal List<HttpExpectation> Expectations = new List<HttpExpectation>();
         
         public TimeSpan ResponseTime { get; set; }
         
         public HttpExpectation Post(string url, string body)
         {
-            var httpExpectation = new HttpExpectation
-            {
-                Request = new HttpRequestExpectation(Http.Post, url, body),
-            };
-
-            Expectations.Add(httpExpectation);
-
-            return httpExpectation;
+            return Method(Http.Post, url, body);
         }
 
         public HttpExpectation Get(string url)
         {
-            var httpExpectation = new HttpExpectation
-            {
-                Request = new HttpRequestExpectation(Http.Get, url),
-            };
-
-            Expectations.Add(httpExpectation);
-
-            return httpExpectation;
+            return Method(Http.Get, url);
         }
 
         public HttpExpectation Put(string url, string body)
         {
-            var httpExpectation = new HttpExpectation
-            {
-                Request = new HttpRequestExpectation(Http.Put, url, body),
-            };
-
-            Expectations.Add(httpExpectation);
-
-            return httpExpectation;
+            return Method(Http.Put, url, body);
         }
 
         public HttpExpectation Delete(string url)
         {
+            return Method(Http.Delete, url);
+        }
+
+        private HttpExpectation Method(Http method, string url, string body = null)
+        {
             var httpExpectation = new HttpExpectation
             {
-                Request = new HttpRequestExpectation(Http.Delete, url),
+                Request = new HttpRequestExpectation(method, url, body)
             };
 
             Expectations.Add(httpExpectation);

--- a/JustFakeIt/FakeServer.cs
+++ b/JustFakeIt/FakeServer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Owin.Hosting;
@@ -11,7 +12,13 @@ namespace JustFakeIt
         public Uri BaseUri { get; private set; }
         public Expect Expect { get; protected set; }
 
+        public IReadOnlyList<HttpRequestExpectation> CapturedRequests
+        {
+            get { return _capturedRequests.ToArray(); }
+        }
+
         private IDisposable _webApp;
+        private readonly IList<HttpRequestExpectation> _capturedRequests;
 
         public FakeServer() : this(Ports.GetFreeTcpPort())
         {
@@ -21,6 +28,7 @@ namespace JustFakeIt
         {
             BaseUri = new UriBuilder(Uri.UriSchemeHttp, "127.0.0.1", basePort).Uri;
             Expect = new Expect();
+            _capturedRequests = new List<HttpRequestExpectation>();
         }
 
         public void Dispose()
@@ -38,7 +46,7 @@ namespace JustFakeIt
 
         public void Start()
         {
-            _webApp = WebApp.Start(BaseUri.ToString(), app => app.Use<ProxyMiddleware>(Expect));
+            _webApp = WebApp.Start(BaseUri.ToString(), app => app.Use<ProxyMiddleware>(Expect, _capturedRequests));
         }
     }
 }

--- a/JustFakeIt/HttpExpectation.cs
+++ b/JustFakeIt/HttpExpectation.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Specialized;
-using System.Net;
+﻿using System.Net;
 using Newtonsoft.Json;
 
 namespace JustFakeIt

--- a/JustFakeIt/HttpRequestExpectation.cs
+++ b/JustFakeIt/HttpRequestExpectation.cs
@@ -6,14 +6,10 @@ namespace JustFakeIt
         public string Url { get; private set; }
         public string Body { get; private set; }
 
-        public HttpRequestExpectation(Http method, string url)
+        public HttpRequestExpectation(Http method, string url, string body = null)
         {
             Method = method;
             Url = url;
-        }
-
-        public HttpRequestExpectation(Http method, string url, string body) : this(method, url)
-        {
             Body = body;
         }
     }

--- a/JustFakeIt/ProxyMiddleware.cs
+++ b/JustFakeIt/ProxyMiddleware.cs
@@ -1,6 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Owin;
 
@@ -9,20 +12,22 @@ namespace JustFakeIt
     public class ProxyMiddleware :  OwinMiddleware
     {
         private readonly Expect _expect;
+        private readonly IList<HttpRequestExpectation> _capturedRequests;
 
-        public ProxyMiddleware(OwinMiddleware next, Expect expect) : base(next)
+        public ProxyMiddleware(OwinMiddleware next, Expect expect, IList<HttpRequestExpectation> capturedRequests = null) : base(next)
         {
             _expect = expect;
+            _capturedRequests = capturedRequests;
         }
 
         public override Task Invoke(IOwinContext context)
         {
-            var delayTask = Task.Delay(_expect.ResponseTime);
+            var body = CaptureRequest(context.Request);
 
             Debug.WriteLine("Looking for registration that matches: ");
             Debug.WriteLine("\t\t\tPath:\t\t\t" + context.Request.Uri.PathAndQuery);
             Debug.WriteLine("\t\t\tMethod:\t\t\t" + context.Request.Method);
-            Debug.WriteLine("\t\t\tBody:\t\t\t" + context.Request.Body);
+            Debug.WriteLine("\t\t\tBody:\t\t\t" + body);
             
             var matchingExpectation = 
                 _expect.Expectations.FirstOrDefault(e => RequestAndExpectedHttpMethodAndPathsMatch(context, e.Request));
@@ -33,19 +38,24 @@ namespace JustFakeIt
                 return context.Response.WriteAsync(new byte[0]);
             }
 
-            foreach (var key in matchingExpectation.Response.Headers.AllKeys)
+            return ProcessMatchingExpectation(context.Response, matchingExpectation);
+        }
+
+        private string CaptureRequest(IOwinRequest request)
+        {
+            string body;
+            using (var sr = new StreamReader(request.Body))
+                body = sr.ReadToEnd();
+            request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+
+            if (_capturedRequests != null)
             {
-                // BUG: http allows duplicate headers; this doesn't.
-                context.Response.Headers.Add(key, new [] {matchingExpectation.Response.Headers[key]});
+                var method = (Http)Enum.Parse(typeof(Http), request.Method, true);
+                var url = request.Uri.GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
+                _capturedRequests.Add(new HttpRequestExpectation(method, url, body));
             }
 
-            context.Response.Headers.Add("Content-Type", new[] {"application/json"});
-            context.Response.StatusCode = (int)matchingExpectation.Response.StatusCode;
-
-            delayTask.Wait();
-
-            return context.Response.WriteAsync(matchingExpectation.Response.ExpectedResult);
-
+            return body;
         }
 
         private static bool RequestAndExpectedHttpMethodAndPathsMatch(IOwinContext context, HttpRequestExpectation requestExpectation)
@@ -54,6 +64,19 @@ namespace JustFakeIt
                 requestExpectation.MatchesActualPath(context.Request.Uri.GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped)) &&
                 requestExpectation.MatchesActualHttpMethod(context.Request.Method) &&
                 requestExpectation.MatchesActualBody(context.Request.Body);
+        }
+
+        private Task ProcessMatchingExpectation(IOwinResponse response, HttpExpectation httpExpectation)
+        {
+            foreach (var key in httpExpectation.Response.Headers.AllKeys)
+                response.Headers.Add(key, new[] { httpExpectation.Response.Headers[key] });
+
+            response.Headers.Add("Content-Type", new[] { "application/json" });
+            response.StatusCode = (int)httpExpectation.Response.StatusCode;
+
+            Task.Delay(_expect.ResponseTime).Wait();
+
+            return response.WriteAsync(httpExpectation.Response.ExpectedResult);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Set a response time by setting the ResponseTime property
  fakeServer.Expect.ResponseTime = TimeSpan.FromSeconds(5);
 ```
 
+Assert against captured requests
+
+```
+ fakeServer.CapturedRequests.Count(x => x.Method == Http.Delete && x.Url == "/some-url").Should().Be(1);
+```
+
 ## Contributing
 
 If you find a bug, have a feature request or even want to contribute an enhancement or fix, please follow the [contributing guidelines](CONTRIBUTING.md) included in the repository.


### PR DESCRIPTION
Hello. I've done a bit of refactoring and implemented the "greedy mode" feature described in https://github.com/justeat/JustFakeIt/issues/10

The way I've done it is to just re-use the `HttpRequestExpectation` class for capturing requests. This won't be able to capture all types of requests because it doesn't support all HTTP verbs. Also, it doesn't capture the request headers either because the `HttpRequestExpectation` class doesn't have a property for headers.

Ultimately, the `HttpRequestExpectation` class should be extended to be able to expect specific headers etc. and once that is done then we can also capture those headers etc. Perhaps the `HttpRequestExpectation` class should be renamed to just `HttpRequest`?