### PR TITLE
Update Newtonsoft.Json to latest version (7.0.1)

### DIFF
--- a/JustFakeIt.Tests/JustFakeIt.Tests.csproj
+++ b/JustFakeIt.Tests/JustFakeIt.Tests.csproj
@@ -48,8 +48,9 @@
     <Reference Include="Microsoft.Owin.Hosting">
       <HintPath>..\packages\Microsoft.Owin.Hosting.2.1.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/JustFakeIt.Tests/packages.config
+++ b/JustFakeIt.Tests/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.SelfHost" version="2.1.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
 </packages>

--- a/JustFakeIt/JustFakeIt.csproj
+++ b/JustFakeIt/JustFakeIt.csproj
@@ -48,8 +48,9 @@
     <Reference Include="Microsoft.Owin.Hosting">
       <HintPath>..\packages\Microsoft.Owin.Hosting.2.1.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/JustFakeIt/JustFakeIt.nuspec
+++ b/JustFakeIt/JustFakeIt.nuspec
@@ -14,7 +14,7 @@
         <tags>owim testing</tags>
         <dependencies>
             <dependency id="Microsoft.Owin.SelfHost" version="[2.1.0]" />
-            <dependency id="Newtonsoft.Json" version="[6, 7)" />
+            <dependency id="Newtonsoft.Json" version="[7, 8)" />
         </dependencies>
     </metadata>
     <files>

--- a/JustFakeIt/packages.config
+++ b/JustFakeIt/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.SelfHost" version="2.1.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is important, as the dependencies here https://www.nuget.org/packages/JustFakeIt/ i.e. Newtonsoft.Json (≥ 6.0 && < 7.0) are preventing updates of NewtonSoft.Json in downstream projects.

Where is the nuspec for this lib generated? I would expect to see this dependency change to something like Newtonsoft.Json (≥ 7.0.1)