### PR TITLE
Prune the default project refs

### DIFF
--- a/JustFakeIt.Tests/JustFakeIt.Tests.csproj
+++ b/JustFakeIt.Tests/JustFakeIt.Tests.csproj
@@ -59,9 +59,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit">
       <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>

--- a/JustFakeIt/JustFakeIt.csproj
+++ b/JustFakeIt/JustFakeIt.csproj
@@ -57,11 +57,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Expect.cs" />


### PR DESCRIPTION
These default project refs aren't used: Data and datasets are not used anywhere. Xml and Xml.Linq is not used in JustFakeIt, only in JustFakeIt.Tests