### PR TITLE
Be lenient about version of Newtonsoft.Json

### DIFF
--- a/JustFakeIt/JustFakeIt.nuspec
+++ b/JustFakeIt/JustFakeIt.nuspec
@@ -14,7 +14,7 @@
         <tags>owim testing</tags>
         <dependencies>
             <dependency id="Microsoft.Owin.SelfHost" version="[2.1.0]" />
-            <dependency id="Newtonsoft.Json" version="[7, 8)" />
+            <dependency id="Newtonsoft.Json" version="6.0.1" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
Specify Newtonsoft.Json version >= 6.0.1. This will allow consumers using Newtonsoft.Json v6.x to update if they want, not will not force it. The only thing that we use from Newtonsoft.Json is `JsonConvert.SeriaizeObject` so I think we can afford to be loose with the required version. 

Syntax as per https://docs.nuget.org/create/versioning : "Generally, the guidance in most cases is to only specify a lower bound, and leave the upper bound open"
Any special reason why this version was specifically >=6 and < 7 before today?