### PR TITLE
Review of code, use `async` on tests where appropriate

### DIFF
--- a/JustFakeIt/ExpectationExtensions.cs
+++ b/JustFakeIt/ExpectationExtensions.cs
@@ -34,7 +34,10 @@ namespace JustFakeIt
 
                 var parameterLength = nextSegmentStart - segmentEnd;
 
-                if (parameterLength <= 0) continue;
+                if (parameterLength <= 0)
+                {
+                    continue;
+                }
 
                 var parameter = actualPath.Substring(segmentEnd, parameterLength);
 

--- a/JustFakeIt/FakeServer.cs
+++ b/JustFakeIt/FakeServer.cs
@@ -33,15 +33,19 @@ namespace JustFakeIt
 
         public void Dispose()
         {
-            if(_webApp != null)
+            if (_webApp != null)
+            {
                 _webApp.Dispose();
+                _webApp = null;
+            }
             
             // Owin Hosting adds trace listeners to the Trace
             // just removing them here to keep the environment clean
-            Trace.Listeners.Cast<TraceListener>()
+            var hostingTraceListeners = Trace.Listeners.Cast<TraceListener>()
                 .Where(listener => listener.Name == "HostingTraceListener")
-                .ToList()
-                .ForEach(x => Trace.Listeners.Remove(x));
+                .ToList();
+
+            hostingTraceListeners.ForEach(x => Trace.Listeners.Remove(x));
         }
 
         public void Start()

--- a/JustFakeIt/Ports.cs
+++ b/JustFakeIt/Ports.cs
@@ -19,7 +19,10 @@ namespace JustFakeIt
 
         private static bool IsAvailable(int port)
         {
-            if (port == 0) return false;
+            if (port == 0)
+            {
+                return false;
+            }
 
             var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
             var allActiveTcpConnections = ipGlobalProperties.GetActiveTcpConnections();

--- a/JustFakeIt/ProxyMiddleware.cs
+++ b/JustFakeIt/ProxyMiddleware.cs
@@ -45,7 +45,10 @@ namespace JustFakeIt
         {
             string body;
             using (var sr = new StreamReader(request.Body))
+            {
                 body = sr.ReadToEnd();
+            }
+
             request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
 
             if (_capturedRequests != null)
@@ -69,7 +72,9 @@ namespace JustFakeIt
         private Task ProcessMatchingExpectation(IOwinResponse response, HttpExpectation httpExpectation)
         {
             foreach (var key in httpExpectation.Response.Headers.AllKeys)
+            {
                 response.Headers.Add(key, new[] { httpExpectation.Response.Headers[key] });
+            }
 
             response.Headers.Add("Content-Type", new[] { "application/json" });
             response.StatusCode = (int)httpExpectation.Response.StatusCode;


### PR DESCRIPTION
 use `async` on http responses in tests where appropriate
and some formatting