### PR TITLE
Owin version asked for in nuspec is specific and doesn't match code

### DIFF
--- a/JustFakeIt/JustFakeIt.nuspec
+++ b/JustFakeIt/JustFakeIt.nuspec
@@ -13,7 +13,7 @@
         <copyright>JUST EAT plc</copyright>
         <tags>owim testing</tags>
         <dependencies>
-            <dependency id="Microsoft.Owin.SelfHost" version="[2.1.0]" />
+            <dependency id="Microsoft.Owin.SelfHost" version="2.1.0" />
             <dependency id="Newtonsoft.Json" version="6.0.1" />
         </dependencies>
     </metadata>


### PR DESCRIPTION
We're now using Microsoft.Owin.* v. 3.0.1 in the code
But when I made that PR I forgot to update the .nuspec file to match, so the package on nuget (https://www.nuget.org/packages/JustFakeIt/ ) still lists the requirement owin == 2.1.0 (i.e. only that version)
Since the owin update was pretty painless, this looks like another case where we can be lenient about the version that we require, and allow >= 2.0.1?