### PR TITLE
Verifying request headers

### DIFF
--- a/JustFakeIt/Expect.cs
+++ b/JustFakeIt/Expect.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 
 namespace JustFakeIt
 {
@@ -9,31 +10,31 @@ namespace JustFakeIt
         
         public TimeSpan ResponseTime { get; set; }
         
-        public HttpExpectation Post(string url, string body)
+        public HttpExpectation Post(string url, string body, WebHeaderCollection expectedHeaders = null)
         {
-            return Method(Http.Post, url, body);
+            return Method(Http.Post, url, body, expectedHeaders);
         }
 
-        public HttpExpectation Get(string url)
+        public HttpExpectation Get(string url, WebHeaderCollection expectedHeaders = null)
         {
-            return Method(Http.Get, url);
+            return Method(Http.Get, url, null, expectedHeaders);
         }
 
-        public HttpExpectation Put(string url, string body)
+        public HttpExpectation Put(string url, string body, WebHeaderCollection expectedHeaders = null)
         {
-            return Method(Http.Put, url, body);
+            return Method(Http.Put, url, body, expectedHeaders);
         }
 
-        public HttpExpectation Delete(string url)
+        public HttpExpectation Delete(string url, WebHeaderCollection expectedHeaders = null)
         {
-            return Method(Http.Delete, url);
+            return Method(Http.Delete, url, null, expectedHeaders);
         }
 
-        private HttpExpectation Method(Http method, string url, string body = null)
+        private HttpExpectation Method(Http method, string url, string body = null, WebHeaderCollection expectedHeaders = null)
         {
             var httpExpectation = new HttpExpectation
             {
-                Request = new HttpRequestExpectation(method, url, body)
+                Request = new HttpRequestExpectation(method, url, body, expectedHeaders)
             };
 
             Expectations.Add(httpExpectation);

--- a/JustFakeIt/HttpRequestExpectation.cs
+++ b/JustFakeIt/HttpRequestExpectation.cs
@@ -1,3 +1,6 @@
+using System.Collections.Specialized;
+using System.Net;
+
 namespace JustFakeIt
 {
     public class HttpRequestExpectation
@@ -5,12 +8,18 @@ namespace JustFakeIt
         public Http Method { get; private set; }
         public string Url { get; private set; }
         public string Body { get; private set; }
+        public WebHeaderCollection Headers { get; set; }
 
-        public HttpRequestExpectation(Http method, string url, string body = null)
+        public HttpRequestExpectation(Http method, string url, string body = null, NameValueCollection headers = null)
         {
             Method = method;
             Url = url;
             Body = body;
+            Headers = new WebHeaderCollection();
+            if (headers != null)
+            {
+                Headers.Add(headers);
+            }
         }
     }
 }


### PR DESCRIPTION
Added an optional Headers property to HttpRequestExpectation. If it is populated but the client does not pass matching request headers a BadRequest http status code is returned, along with details of which expected headers were missing in the response body.

Usage is shown by two new tests, covering the case where the headers match, and the case where they do not match. The request headers parameter is optional when calling Expect.Get etc, so existing code should not be impacted.

Renamed an existing test to make it clear that it deals with response headers.