### PR TITLE
Make FakeServer more resiliant in a multi-threading environment

### DIFF
--- a/JustFakeIt/Ports.cs
+++ b/JustFakeIt/Ports.cs
@@ -8,6 +8,8 @@ namespace JustFakeIt
     {
         private static readonly Random Random = new Random();
 
+        public static readonly object FreePortCreationLock = new object();
+
         public static int GetFreeTcpPort()
         {
             var port = 0;


### PR DESCRIPTION
When running multiple tests in parallel (e.g. in NCrunch), FakeServer can interfere with itself. This is to fix that issue.
