### PR TITLE
Add support for returning from files and razor templates

### DIFF
--- a/JustFakeIt.Tests/FakeServerScenarios.cs
+++ b/JustFakeIt.Tests/FakeServerScenarios.cs
@@ -448,7 +448,26 @@ namespace JustFakeIt.Tests
         }
 
         [Fact]
-        public void FakeServer_ShouldExecuteResponseExpectationCallback_ReturnExpectedData()
+        public async Task FakeServer_ExpectGetToAnEndpointWithAFiveSecondResponseTime_ResponseTimeIsGreaterThanFiveSeconds()
+        {
+            var expectedResult = new { ResourceId = 1234 };
+            var expectedResponseTime = TimeSpan.FromSeconds(1);
+
+            using (var fakeServer = new FakeServer())
+            {
+                fakeServer.Expect.ResponseTime = expectedResponseTime;
+                fakeServer.Expect.Get("/some-url").Returns(expectedResult).RespondsIn(TimeSpan.FromSeconds(5)).WithHttpStatus(HttpStatusCode.OK);
+                fakeServer.Start();
+
+                var stopwatch = Stopwatch.StartNew();
+
+                await fakeServer.Client.GetAsync("/some-url");
+
+                stopwatch.Stop();
+
+                stopwatch.Elapsed.Should().BeGreaterOrEqualTo(expectedResponseTime);
+            }
+        }
         {
             const string expectedResult = "Some String Data";
             const string baseAddress = "http://localhost:12354";

--- a/JustFakeIt.Tests/FakeServerScenarios.cs
+++ b/JustFakeIt.Tests/FakeServerScenarios.cs
@@ -17,14 +17,14 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url).Returns(expectedResult);
+                fakeServer.Expect.Get(path).Returns(expectedResult);
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetStringAsync(url);
+                var result = await fakeServer.Client.GetStringAsync(path);
                 result.Should().Be(expectedResult);
             }
         }
@@ -34,14 +34,14 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url).Returns(expectedResult, new WebHeaderCollection { { "foo", "bar" } });
+                fakeServer.Expect.Get(path).Returns(expectedResult, new WebHeaderCollection { { "foo", "bar" } });
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetAsync(url);
+                var result = await fakeServer.Client.GetAsync(path);
 
                 result.Content.ReadAsStringAsync().Result.Should().Be(expectedResult);
                 result.Headers.Should().ContainSingle(x => x.Key == "foo");
@@ -53,14 +53,14 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url).Returns(expectedResult).WithHeader("Content-Language", "es").WithHeader("Some-Header", "Header-McHeaderFace");
+                fakeServer.Expect.Get(path).Returns(expectedResult).WithHeader("Content-Language", "es").WithHeader("Some-Header", "Header-McHeaderFace");
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetAsync(url);
+                var result = await fakeServer.Client.GetAsync(path);
 
                 result.Content.ReadAsStringAsync().Result.Should().Be(expectedResult);
                 result.Headers.Should().ContainSingle(x => x.Key == "Some-Header");
@@ -72,13 +72,10 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            var port = Ports.GetFreeTcpPort();
 
-            var baseAddress = "http://localhost:" + port;
+            const string path = "/some-path";
 
-            const string url = "/some-url";
-
-            using (var fakeServer = new FakeServer(port))
+            using (var fakeServer = new FakeServer())
             {
                 var expectedRequestHeaders = new WebHeaderCollection
                 {
@@ -87,17 +84,17 @@ namespace JustFakeIt.Tests
                     {"X-Dummy3", "dummy3val"}
                 };
 
-                fakeServer.Expect.Get(url, expectedRequestHeaders).Returns(expectedResult);
+                fakeServer.Expect.Get(path, expectedRequestHeaders).Returns(expectedResult);
                 fakeServer.Start();
 
-                var client = new HttpClient { BaseAddress = new Uri(baseAddress) };
+                var client = fakeServer.Client;
 
                 client.DefaultRequestHeaders.Accept.Clear();
                 client.DefaultRequestHeaders.TryAddWithoutValidation("X-Dummy1", "dummy1val");
                 client.DefaultRequestHeaders.TryAddWithoutValidation("X-Dummy2", "dummy2val");
                 client.DefaultRequestHeaders.TryAddWithoutValidation("X-Dummy3", "dummy3val");
 
-                var result = await client.GetAsync(url);
+                var result = await client.GetAsync(path);
 
                 result.StatusCode.Should().Be(HttpStatusCode.OK);
                 result.Content.ReadAsStringAsync().Result.Should().Be(expectedResult);
@@ -109,13 +106,10 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "X-Dummy1 header value not as expected.\r\n\tExpected: dummy1val\r\n\tProvided: other1val\r\nX-Dummy2 header was not provided.\r\n";
 
-            var port = Ports.GetFreeTcpPort();
 
-            var baseAddress = "http://localhost:" + port;
+            const string path = "/some-path";
 
-            const string url = "/some-url";
-
-            using (var fakeServer = new FakeServer(port))
+            using (var fakeServer = new FakeServer())
             {
                 var expectedRequestHeaders = new WebHeaderCollection
                 {
@@ -124,16 +118,15 @@ namespace JustFakeIt.Tests
                     {"X-Dummy3", "dummy3val"}   // will match
                 };
 
-                fakeServer.Expect.Get(url, expectedRequestHeaders).Returns(expectedResult);
+                fakeServer.Expect.Get(path, expectedRequestHeaders).Returns(expectedResult);
                 fakeServer.Start();
 
-                var client = new HttpClient { BaseAddress = new Uri(baseAddress) };
-
+                var client = fakeServer.Client;
                 client.DefaultRequestHeaders.Accept.Clear();
                 client.DefaultRequestHeaders.TryAddWithoutValidation("X-Dummy1", "other1val");
                 client.DefaultRequestHeaders.TryAddWithoutValidation("X-Dummy3", "dummy3val");
 
-                var result = await client.GetAsync(url);
+                var result = await client.GetAsync(path);
 
                 result.StatusCode.Should().Be(HttpStatusCode.BadRequest);
                 result.Content.ReadAsStringAsync().Result.Should().Be(expectedResult);
@@ -145,15 +138,15 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
             
-            const string url = "/some-url?id=1234";
+            const string path = "/some-path?id=1234";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url).Returns(expectedResult);
+                fakeServer.Expect.Get(path).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetStringAsync(url);
+                var result = await fakeServer.Client.GetStringAsync(path);
 
                 result.Should().Be(expectedResult);
             }
@@ -164,15 +157,15 @@ namespace JustFakeIt.Tests
         {
             var expectedResult = new { RestaurantId = 1234 };
 
-            const string url = "/restaurant/1234";
+            const string path = "/restaurant/1234";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url).Returns(expectedResult);
+                fakeServer.Expect.Get(path).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var resp = await fakeServer.Client.GetStringAsync(url);
+                var resp = await fakeServer.Client.GetStringAsync(path);
                 var result = JsonConvert.DeserializeObject<dynamic>(resp);
 
                 Assert.Equal(expectedResult.RestaurantId, (int)result.RestaurantId);
@@ -184,17 +177,17 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             var content = new StringContent(string.Empty);
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Post(url, string.Empty).Returns(expectedResult);
+                fakeServer.Expect.Post(path, string.Empty).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var resp = await fakeServer.Client.PostAsync(url, content);
+                var resp = await fakeServer.Client.PostAsync(path, content);
                 var result = await resp.Content.ReadAsStringAsync();
 
                 result.Should().Be(expectedResult);
@@ -206,15 +199,15 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Post(url, "jibberish").Returns(expectedResult);
+                fakeServer.Expect.Post(path, "jibberish").Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var resp = await fakeServer.Client.PostAsync(url, new StringContent(string.Empty));
+                var resp = await fakeServer.Client.PostAsync(path, new StringContent(string.Empty));
 
                 resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
             }
@@ -227,7 +220,7 @@ namespace JustFakeIt.Tests
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get("/some-jibberish-url").Returns(expectedResult);
+                fakeServer.Expect.Get("/some-jibberish-path").Returns(expectedResult);
 
                 fakeServer.Start();
 
@@ -241,7 +234,7 @@ namespace JustFakeIt.Tests
         public async Task FakeServer_ExpectGetWithMismatchingMethod_Returns404()
         {
             const string expectedResult = "Some String Data";
-            const string path = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
@@ -260,15 +253,15 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Put(url, string.Empty).Returns(expectedResult);
+                fakeServer.Expect.Put(path, string.Empty).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var resp = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
+                var resp = await fakeServer.Client.PutAsync(path, new StringContent(string.Empty));
                 var result = await resp.Content.ReadAsStringAsync();
 
                 result.Should().Be(expectedResult);
@@ -280,14 +273,14 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Delete(url).Returns(expectedResult);
+                fakeServer.Expect.Delete(path).Returns(expectedResult);
                 fakeServer.Start();
 
-                var resp = await fakeServer.Client.DeleteAsync(url);
+                var resp = await fakeServer.Client.DeleteAsync(path);
                 var result = await resp.Content.ReadAsStringAsync();
 
                 result.Should().Be(expectedResult);
@@ -297,18 +290,18 @@ namespace JustFakeIt.Tests
         [Fact]
         public async Task FakeServer_ExpectGetReturnsGeneratedTemplateFromPath_ResponseMatchesTemplate()
         {
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url)
+                fakeServer.Expect.Get(path)
                     .ReturnsFromTemplate(@"TestData\TestTemplate.json", new { Id = 2343, UserId = 2343, UserEmail = "mick.hucknall@just-eat.com" })
                     .RespondsIn(TimeSpan.FromSeconds(1))
                     .WithHttpStatus(HttpStatusCode.Accepted);
 
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetStringAsync(url);
+                var result = await fakeServer.Client.GetStringAsync(path);
 
                 dynamic deserialised = JsonConvert.DeserializeObject(result);
 
@@ -321,16 +314,16 @@ namespace JustFakeIt.Tests
         [Fact]
         public async Task FakeServer_ExpectGetReturnsFileContent_ResponseMatchesExpectation()
         {
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url)
+                fakeServer.Expect.Get(path)
                     .ReturnsFromFile(@"TestData\TestResponse.json");
                 
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetStringAsync(url);
+                var result = await fakeServer.Client.GetStringAsync(path);
 
                 dynamic deserialised = JsonConvert.DeserializeObject(result);
 
@@ -343,14 +336,14 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Put(url, string.Empty).Returns(HttpStatusCode.Created, expectedResult);
+                fakeServer.Expect.Put(path, string.Empty).Returns(HttpStatusCode.Created, expectedResult);
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
+                var result = await fakeServer.Client.PutAsync(path, new StringContent(string.Empty));
                 
                 result.StatusCode.Should().Be(HttpStatusCode.Created);
             }
@@ -361,14 +354,14 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Put(url, string.Empty).Returns(expectedResult).WithHttpStatus(HttpStatusCode.Created);
+                fakeServer.Expect.Put(path, string.Empty).Returns(expectedResult).WithHttpStatus(HttpStatusCode.Created);
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
+                var result = await fakeServer.Client.PutAsync(path, new StringContent(string.Empty));
 
                 result.StatusCode.Should().Be(HttpStatusCode.Created);
             }
@@ -382,10 +375,10 @@ namespace JustFakeIt.Tests
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Put("/some-url", body).Returns(HttpStatusCode.Created, expectedResult);
+                fakeServer.Expect.Put("/some-path", body).Returns(HttpStatusCode.Created, expectedResult);
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.PutAsync("/some-url", new StringContent(body));
+                var result = await fakeServer.Client.PutAsync("/some-path", new StringContent(body));
 
                 var content = await result.Content.ReadAsStringAsync();
 
@@ -399,14 +392,14 @@ namespace JustFakeIt.Tests
         {
             var expectedResult = new {RestaurantId = 1234};
 
-            const string url = "/some-url";
+            const string path = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Put(url, string.Empty).Returns(HttpStatusCode.Created, expectedResult);
+                fakeServer.Expect.Put(path, string.Empty).Returns(HttpStatusCode.Created, expectedResult);
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
+                var result = await fakeServer.Client.PutAsync(path, new StringContent(string.Empty));
 
                 result.StatusCode.Should().Be(HttpStatusCode.Created);
             }
@@ -417,34 +410,34 @@ namespace JustFakeIt.Tests
         {
             var expectedResult = new { ResourceId = 1234 };
 
-            const string fakeurl = "/some-resource/{ignore}/some-resource?date={ignore}&type={ignore}";
-            const string actualurl = "/some-resource/1234/some-resource?date=2015-02-06T09:52:10&type=1";
+            const string fakepath = "/some-resource/{ignore}/some-resource?date={ignore}&type={ignore}";
+            const string actualpath = "/some-resource/1234/some-resource?date=2015-02-06T09:52:10&type=1";
 
             using (var fakeServer = new FakeServer(12354))
             {
-                fakeServer.Expect.Get(fakeurl).Returns(HttpStatusCode.Accepted, expectedResult);
+                fakeServer.Expect.Get(fakepath).Returns(HttpStatusCode.Accepted, expectedResult);
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetAsync(actualurl);
+                var result = await fakeServer.Client.GetAsync(actualpath);
 
                 result.StatusCode.Should().Be(HttpStatusCode.Accepted);
             }
         }
 
         [Fact]
-        public async Task FakeServer_IgnoredParameterInRestfulUrl_Returns200()
+        public async Task FakeServer_IgnoredParameterInRestfulpath_Returns200()
         {
             var expectedResult = new { ResourceId = 1234 };
 
-            const string fakeUrl = "/some-resource/{ignore}/some-method";
-            const string actualUrl = "/some-resource/1234/some-method";
+            const string fakepath = "/some-resource/{ignore}/some-method";
+            const string actualpath = "/some-resource/1234/some-method";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(fakeUrl).Returns(HttpStatusCode.Accepted, expectedResult);
+                fakeServer.Expect.Get(fakepath).Returns(HttpStatusCode.Accepted, expectedResult);
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetAsync(actualUrl);
+                var result = await fakeServer.Client.GetAsync(actualpath);
 
                 result.StatusCode.Should().Be(HttpStatusCode.Accepted);
             }            
@@ -456,17 +449,17 @@ namespace JustFakeIt.Tests
             var expectedResultA = "1234";
             var expectedResultB = "5678";
 
-            const string fakeurl = "/some-url";
+            const string fakepath = "/some-path";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Post(fakeurl, "messageA").Returns(HttpStatusCode.OK, expectedResultA);
-                fakeServer.Expect.Post(fakeurl, "messageB").Returns(HttpStatusCode.OK, expectedResultB);
+                fakeServer.Expect.Post(fakepath, "messageA").Returns(HttpStatusCode.OK, expectedResultA);
+                fakeServer.Expect.Post(fakepath, "messageB").Returns(HttpStatusCode.OK, expectedResultB);
 
                 fakeServer.Start();
 
-                var resultA = await fakeServer.Client.PostAsync(fakeurl, new StringContent("messageA"));
-                var resultB = await fakeServer.Client.PostAsync(fakeurl, new StringContent("messageB"));
+                var resultA = await fakeServer.Client.PostAsync(fakepath, new StringContent("messageA"));
+                var resultB = await fakeServer.Client.PostAsync(fakepath, new StringContent("messageB"));
 
                 (await resultA.Content.ReadAsStringAsync()).Should().Be(expectedResultA);
                 (await resultB.Content.ReadAsStringAsync()).Should().Be(expectedResultB);
@@ -477,17 +470,17 @@ namespace JustFakeIt.Tests
         public async Task FakeServer_ExpectAllEndpointsToHaveAFiveSecondResponseTime_ResponseTimeIsGreaterThanFiveSeconds()
         {
             var expectedResult = new { ResourceId = 1234 };
-            var expectedResponseTime = TimeSpan.FromSeconds(5);
+            var expectedResponseTime = TimeSpan.FromSeconds(6);
             
             using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.ResponseTime = expectedResponseTime;
-                fakeServer.Expect.Get("/some-url").Returns(HttpStatusCode.OK, expectedResult);
+                fakeServer.Expect.Get("/some-path").Returns(HttpStatusCode.OK, expectedResult);
                 fakeServer.Start();
 
                 var stopwatch = Stopwatch.StartNew();
 
-                await fakeServer.Client.GetAsync("/some-url");
+                await fakeServer.Client.GetAsync("/some-path");
 
                 stopwatch.Stop();
 
@@ -504,12 +497,12 @@ namespace JustFakeIt.Tests
             using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.ResponseTime = expectedResponseTime;
-                fakeServer.Expect.Get("/some-url").Returns(expectedResult).RespondsIn(TimeSpan.FromSeconds(5)).WithHttpStatus(HttpStatusCode.OK);
+                fakeServer.Expect.Get("/some-path").Returns(expectedResult).RespondsIn(TimeSpan.FromSeconds(5)).WithHttpStatus(HttpStatusCode.OK);
                 fakeServer.Start();
 
                 var stopwatch = Stopwatch.StartNew();
 
-                await fakeServer.Client.GetAsync("/some-url");
+                await fakeServer.Client.GetAsync("/some-path");
 
                 stopwatch.Stop();
 
@@ -522,15 +515,15 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            const string url = "/some-url?id=1234";
+            const string path = "/some-path?id=1234";
 
             using (var fakeServer = new FakeServer())
             {
-                fakeServer.Expect.Get(url).Callback(() => new HttpResponseExpectation(HttpStatusCode.OK, expectedResult));
+                fakeServer.Expect.Get(path).Callback(() => new HttpResponseExpectation(HttpStatusCode.OK, expectedResult));
 
                 fakeServer.Start();
 
-                var result = await fakeServer.Client.GetStringAsync(url);
+                var result = await fakeServer.Client.GetStringAsync(path);
 
                 result.Should().Be(expectedResult);
             }
@@ -544,21 +537,21 @@ namespace JustFakeIt.Tests
                 fakeServer.Start();
                 var baseAddress = fakeServer.BaseUri;
                 
-                var url1 = "/request1";
-                var url2 = "/request2";
-                var url3 = "/request3";
-                var url4 = "/request4";
+                var path1 = "/request1";
+                var path2 = "/request2";
+                var path3 = "/request3";
+                var path4 = "/request4";
 
                 var httpClient = new HttpClient();
-                await httpClient.DeleteAsync(baseAddress + url1);
-                await Repeat(() => httpClient.GetAsync(baseAddress + url2), 2);
-                await Repeat(() => httpClient.PostAsync(baseAddress + url3, new StringContent(url3)), 3);
-                await Repeat(() => httpClient.PutAsync(baseAddress + url4, new StringContent(url4)), 4);
+                await httpClient.DeleteAsync(baseAddress + path1);
+                await Repeat(() => httpClient.GetAsync(baseAddress + path2), 2);
+                await Repeat(() => httpClient.PostAsync(baseAddress + path3, new StringContent(path3)), 3);
+                await Repeat(() => httpClient.PutAsync(baseAddress + path4, new StringContent(path4)), 4);
 
-                fakeServer.CapturedRequests.Count(x => x.Method == Http.Delete && x.Url == url1).Should().Be(1);
-                fakeServer.CapturedRequests.Count(x => x.Method == Http.Get && x.Url == url2).Should().Be(2);
-                fakeServer.CapturedRequests.Count(x => x.Method == Http.Post && x.Url == url3 && x.Body == url3).Should().Be(3);
-                fakeServer.CapturedRequests.Count(x => x.Method == Http.Put && x.Url == url4 && x.Body == url4).Should().Be(4);
+                fakeServer.CapturedRequests.Count(x => x.Method == Http.Delete && x.Url == path1).Should().Be(1);
+                fakeServer.CapturedRequests.Count(x => x.Method == Http.Get && x.Url == path2).Should().Be(2);
+                fakeServer.CapturedRequests.Count(x => x.Method == Http.Post && x.Url == path3 && x.Body == path3).Should().Be(3);
+                fakeServer.CapturedRequests.Count(x => x.Method == Http.Put && x.Url == path4 && x.Body == path4).Should().Be(4);
             }
         }
 

--- a/JustFakeIt.Tests/FakeServerScenarios.cs
+++ b/JustFakeIt.Tests/FakeServerScenarios.cs
@@ -13,7 +13,7 @@ namespace JustFakeIt.Tests
     public class FakeServerScenarios
     {
         [Fact]
-        public void FakeServer_ExpectGetReturnsString_ResponseMatchesExpectation()
+        public async Task FakeServer_ExpectGetReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
 
@@ -23,11 +23,8 @@ namespace JustFakeIt.Tests
             {
                 fakeServer.Expect.Get(url).Returns(expectedResult);
                 fakeServer.Start();
-                
-                var baseAddress = fakeServer.BaseUri;
-                var uri = new Uri(baseAddress + url);
-                var result = new WebClient().DownloadString(uri);
 
+                var result = await fakeServer.Client.GetStringAsync(url);
                 result.Should().Be(expectedResult);
             }
         }
@@ -37,22 +34,36 @@ namespace JustFakeIt.Tests
         {
             const string expectedResult = "Some String Data";
 
-            var port = Ports.GetFreeTcpPort();
-
-            var baseAddress = "http://localhost:" + port;
-
             const string url = "/some-url";
 
-            using (var fakeServer = new FakeServer(port))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Get(url).Returns(expectedResult, new WebHeaderCollection { { "foo", "bar" } });
                 fakeServer.Start();
 
-                var client = new HttpClient {BaseAddress = new Uri(baseAddress)};
-                var result = await client.GetAsync(url);
+                var result = await fakeServer.Client.GetAsync(url);
 
                 result.Content.ReadAsStringAsync().Result.Should().Be(expectedResult);
                 result.Headers.Should().ContainSingle(x => x.Key == "foo");
+            }
+        }
+
+        [Fact]
+        public async Task FakeServer_ExpectGetWithResponseHeadersSpecifiedFluently_ResponseMatchesExpectionAndHasHeaders()
+        {
+            const string expectedResult = "Some String Data";
+
+            const string url = "/some-url";
+
+            using (var fakeServer = new FakeServer())
+            {
+                fakeServer.Expect.Get(url).Returns(expectedResult).WithHeader("Content-Language", "es").WithHeader("Some-Header", "Header-McHeaderFace");
+                fakeServer.Start();
+
+                var result = await fakeServer.Client.GetAsync(url);
+
+                result.Content.ReadAsStringAsync().Result.Should().Be(expectedResult);
+                result.Headers.Should().ContainSingle(x => x.Key == "Some-Header");
             }
         }
 
@@ -130,167 +141,200 @@ namespace JustFakeIt.Tests
         }
 
         [Fact]
-        public void FakeServer_ExpectGetWithQueryParametersReturnsString_ResponseMatchesExpectation()
+        public async Task FakeServer_ExpectGetWithQueryParametersReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
             
             const string url = "/some-url?id=1234";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Get(url).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var result = new WebClient().DownloadString(uri);
+                var result = await fakeServer.Client.GetStringAsync(url);
 
                 result.Should().Be(expectedResult);
             }
         }
 
         [Fact]
-        public void FakeServer_ExpectGetReturnsObject_ResponseMatchesExpectation()
+        public async Task FakeServer_ExpectGetReturnsObject_ResponseMatchesExpectation()
         {
             var expectedResult = new { RestaurantId = 1234 };
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/restaurant/1234";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Get(url).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var stringResult = new WebClient().DownloadString(uri);
-                var result = JsonConvert.DeserializeObject<dynamic>(stringResult);
+                var resp = await fakeServer.Client.GetStringAsync(url);
+                var result = JsonConvert.DeserializeObject<dynamic>(resp);
 
                 Assert.Equal(expectedResult.RestaurantId, (int)result.RestaurantId);
             }
         }
 
         [Fact]
-        public void FakeServer_ExpectPostWithNoBodyReturnsString_ResponseMatchesExpectation()
+        public async Task FakeServer_ExpectPostWithNoBodyReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            var content = new StringContent(string.Empty);
+
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Post(url, string.Empty).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var result = new WebClient().UploadString(uri, string.Empty);
+                var resp = await fakeServer.Client.PostAsync(url, content);
+                var result = await resp.Content.ReadAsStringAsync();
 
                 result.Should().Be(expectedResult);
             }
         }
 
         [Fact]
-        public void FakeServer_ExpectPostWithMismatchingBody_Returns404()
+        public async Task FakeServer_ExpectPostWithMismatchingBody_Returns404()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Post(url, "jibberish").Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var ex = Assert.Throws<WebException>(() => new WebClient().UploadString(uri, string.Empty));
+                var resp = await fakeServer.Client.PostAsync(url, new StringContent(string.Empty));
 
-                ((HttpWebResponse)ex.Response).StatusCode.Should().Be(HttpStatusCode.NotFound);
+                resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
             }
         }
 
         [Fact]
-        public void FakeServer_ExpectGetWithMismatchingPath_Returns404()
+        public async Task FakeServer_ExpectGetWithMismatchingPath_Returns404()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Get("/some-jibberish-url").Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + "/home");
-                var ex = Assert.Throws<WebException>(() => new WebClient().DownloadString(uri));
+                var resp = await fakeServer.Client.GetAsync("/home");
 
-                ((HttpWebResponse)ex.Response).StatusCode.Should().Be(HttpStatusCode.NotFound);
+                resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
             }
         }
 
         [Fact]
-        public void FakeServer_ExpectGetWithMismatchingMethod_Returns404()
+        public async Task FakeServer_ExpectGetWithMismatchingMethod_Returns404()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
             const string path = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Get(path).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + path);
-                var ex = Assert.Throws<WebException>(() => new WebClient().UploadString(uri, string.Empty));
+                var resp = await fakeServer.Client.PostAsync(path, new StringContent(string.Empty));
 
-                ((HttpWebResponse)ex.Response).StatusCode.Should().Be(HttpStatusCode.NotFound);
+                resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
             }
         }
 
         [Fact]
-        public void FakeServer_ExpectPutWithNoBodyReturnsString_ResponseMatchesExpectation()
+        public async Task FakeServer_ExpectPutWithNoBodyReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Put(url, string.Empty).Returns(expectedResult);
 
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var result = new WebClient().UploadString(uri, "PUT", string.Empty);
+                var resp = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
+                var result = await resp.Content.ReadAsStringAsync();
 
                 result.Should().Be(expectedResult);
             }
         }
 
         [Fact]
-        public void FakeServer_ExpectDeleteReturnsString_ResponseMatchesExpectation()
+        public async Task FakeServer_ExpectDeleteReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Delete(url).Returns(expectedResult);
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var result = new WebClient().UploadString(uri, "DELETE", string.Empty);
+                var resp = await fakeServer.Client.DeleteAsync(url);
+                var result = await resp.Content.ReadAsStringAsync();
 
                 result.Should().Be(expectedResult);
+            }
+        }
+
+        [Fact]
+        public async Task FakeServer_ExpectGetReturnsGeneratedTemplateFromPath_ResponseMatchesTemplate()
+        {
+            const string url = "/some-url";
+
+            using (var fakeServer = new FakeServer())
+            {
+                fakeServer.Expect.Get(url)
+                    .ReturnsFromTemplate(@"TestData\TestTemplate.json", new { Id = 2343, UserId = 2343, UserEmail = "mick.hucknall@just-eat.com" })
+                    .RespondsIn(TimeSpan.FromSeconds(1))
+                    .WithHttpStatus(HttpStatusCode.Accepted);
+
+                fakeServer.Start();
+
+                var result = await fakeServer.Client.GetStringAsync(url);
+
+                dynamic deserialised = JsonConvert.DeserializeObject(result);
+
+                ((int)deserialised.id).Should().Be(2343);
+                ((int)deserialised.userId).Should().Be(2343);
+                ((string)deserialised.userEmail).Should().Be("mick.hucknall@just-eat.com");
+            }
+        }
+
+        [Fact]
+        public async Task FakeServer_ExpectGetReturnsFileContent_ResponseMatchesExpectation()
+        {
+            const string url = "/some-url";
+
+            using (var fakeServer = new FakeServer())
+            {
+                fakeServer.Expect.Get(url)
+                    .ReturnsFromFile(@"TestData\TestResponse.json");
+                
+                fakeServer.Start();
+
+                var result = await fakeServer.Client.GetStringAsync(url);
+
+                dynamic deserialised = JsonConvert.DeserializeObject(result);
+
+                ((string)deserialised.name).Should().Be("Mick Hucknall");
             }
         }
 
@@ -298,18 +342,34 @@ namespace JustFakeIt.Tests
         public async Task FakeServer_ExpectPutWithNoBodyReturns201_Returns201()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Put(url, string.Empty).Returns(HttpStatusCode.Created, expectedResult);
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var result = await new HttpClient().PutAsync(uri, new StringContent(String.Empty));
+                var result = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
                 
+                result.StatusCode.Should().Be(HttpStatusCode.Created);
+            }
+        }
+
+        [Fact]
+        public async Task FakeServer_ExpectPutWithNoBodyReturns2011_Returns201()
+        {
+            const string expectedResult = "Some String Data";
+
+            const string url = "/some-url";
+
+            using (var fakeServer = new FakeServer())
+            {
+                fakeServer.Expect.Put(url, string.Empty).Returns(expectedResult).WithHttpStatus(HttpStatusCode.Created);
+                fakeServer.Start();
+
+                var result = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
+
                 result.StatusCode.Should().Be(HttpStatusCode.Created);
             }
         }
@@ -320,13 +380,12 @@ namespace JustFakeIt.Tests
             const string expectedResult = "{\"Complex\":{\"Property1\":1,\"Property2\":true}}";
             const string body = "{\"Complex\":1}";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Put("/some-url", body).Returns(HttpStatusCode.Created, expectedResult);
                 fakeServer.Start();
 
-                var uri = new Uri("http://localhost:12354" + "/some-url");
-                var result = await new HttpClient().PutAsync(uri, new StringContent(body));
+                var result = await fakeServer.Client.PutAsync("/some-url", new StringContent(body));
 
                 var content = await result.Content.ReadAsStringAsync();
 
@@ -339,17 +398,15 @@ namespace JustFakeIt.Tests
         public async Task FakeServer_ExpectPutWithObjectBodyReturns201_Returns201()
         {
             var expectedResult = new {RestaurantId = 1234};
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Put(url, string.Empty).Returns(HttpStatusCode.Created, expectedResult);
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + url);
-                var result = await new HttpClient().PutAsync(uri, new StringContent(String.Empty));
+                var result = await fakeServer.Client.PutAsync(url, new StringContent(string.Empty));
 
                 result.StatusCode.Should().Be(HttpStatusCode.Created);
             }
@@ -359,7 +416,6 @@ namespace JustFakeIt.Tests
         public async Task FakeServer_IgnoredParameter_Returns200()
         {
             var expectedResult = new { ResourceId = 1234 };
-            const string baseAddress = "http://localhost:12354";
 
             const string fakeurl = "/some-resource/{ignore}/some-resource?date={ignore}&type={ignore}";
             const string actualurl = "/some-resource/1234/some-resource?date=2015-02-06T09:52:10&type=1";
@@ -369,8 +425,7 @@ namespace JustFakeIt.Tests
                 fakeServer.Expect.Get(fakeurl).Returns(HttpStatusCode.Accepted, expectedResult);
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + actualurl);
-                var result = await new HttpClient().GetAsync(uri);
+                var result = await fakeServer.Client.GetAsync(actualurl);
 
                 result.StatusCode.Should().Be(HttpStatusCode.Accepted);
             }
@@ -380,66 +435,59 @@ namespace JustFakeIt.Tests
         public async Task FakeServer_IgnoredParameterInRestfulUrl_Returns200()
         {
             var expectedResult = new { ResourceId = 1234 };
-            const string baseAddress = "http://localhost:12354";
 
             const string fakeUrl = "/some-resource/{ignore}/some-method";
             const string actualUrl = "/some-resource/1234/some-method";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Get(fakeUrl).Returns(HttpStatusCode.Accepted, expectedResult);
                 fakeServer.Start();
 
-                var uri = new Uri(baseAddress + actualUrl);
-                var result = await new HttpClient().GetAsync(uri);
+                var result = await fakeServer.Client.GetAsync(actualUrl);
 
                 result.StatusCode.Should().Be(HttpStatusCode.Accepted);
             }            
         }
 
         [Fact]
-        public void FakeServer_ShouldHandleMultipleRegistrationOnSameEndPoint_WithDifferentBodies_ReturnExpectedData()
+        public async Task FakeServer_ShouldHandleMultipleRegistrationOnSameEndPoint_WithDifferentBodies_ReturnExpectedData()
         {
             var expectedResultA = "1234";
             var expectedResultB = "5678";
 
-            const string baseAddress = "http://localhost:12354";
             const string fakeurl = "/some-url";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Post(fakeurl, "messageA").Returns(HttpStatusCode.OK, expectedResultA);
                 fakeServer.Expect.Post(fakeurl, "messageB").Returns(HttpStatusCode.OK, expectedResultB);
 
                 fakeServer.Start();
 
-                var resultA = new WebClient().UploadString(new Uri(baseAddress + fakeurl), "POST", "messageA");
-                var resultB = new WebClient().UploadString(new Uri(baseAddress + fakeurl), "POST", "messageB");
+                var resultA = await fakeServer.Client.PostAsync(fakeurl, new StringContent("messageA"));
+                var resultB = await fakeServer.Client.PostAsync(fakeurl, new StringContent("messageB"));
 
-                resultA.Should().Be(expectedResultA);
-                resultB.Should().Be(expectedResultB);
+                (await resultA.Content.ReadAsStringAsync()).Should().Be(expectedResultA);
+                (await resultB.Content.ReadAsStringAsync()).Should().Be(expectedResultB);
             }
         }
 
         [Fact]
-        public async Task FakeServer_ExpectGetToAnEndpointWithAFiveSecondResponseTime_ResponseTimeIsGreaterThanFiveSeconds()
+        public async Task FakeServer_ExpectAllEndpointsToHaveAFiveSecondResponseTime_ResponseTimeIsGreaterThanFiveSeconds()
         {
             var expectedResult = new { ResourceId = 1234 };
-            const string baseAddress = "http://localhost:12354";
             var expectedResponseTime = TimeSpan.FromSeconds(5);
-
-            const string fakeUrl = "/some-url";
             
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.ResponseTime = expectedResponseTime;
-                fakeServer.Expect.Get(fakeUrl).Returns(HttpStatusCode.OK, expectedResult);
+                fakeServer.Expect.Get("/some-url").Returns(HttpStatusCode.OK, expectedResult);
                 fakeServer.Start();
 
                 var stopwatch = Stopwatch.StartNew();
 
-                var uri = new Uri(baseAddress + fakeUrl);
-                await new HttpClient().GetAsync(uri);
+                await fakeServer.Client.GetAsync("/some-url");
 
                 stopwatch.Stop();
 
@@ -468,19 +516,21 @@ namespace JustFakeIt.Tests
                 stopwatch.Elapsed.Should().BeGreaterOrEqualTo(expectedResponseTime);
             }
         }
+
+        [Fact]
+        public async Task FakeServer_ShouldExecuteResponseExpectationCallback_ReturnExpectedData()
         {
             const string expectedResult = "Some String Data";
-            const string baseAddress = "http://localhost:12354";
 
             const string url = "/some-url?id=1234";
 
-            using (var fakeServer = new FakeServer(12354))
+            using (var fakeServer = new FakeServer())
             {
                 fakeServer.Expect.Get(url).Callback(() => new HttpResponseExpectation(HttpStatusCode.OK, expectedResult));
 
                 fakeServer.Start();
 
-                var result = new WebClient().DownloadString(new Uri(baseAddress + url));
+                var result = await fakeServer.Client.GetStringAsync(url);
 
                 result.Should().Be(expectedResult);
             }

--- a/JustFakeIt.Tests/JustFakeIt.Tests.csproj
+++ b/JustFakeIt.Tests/JustFakeIt.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,7 +12,8 @@
     <AssemblyName>JustFakeIt.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>2baadb29</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,12 +74,16 @@
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -87,7 +92,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+    <Content Include="TestData\TestTemplate.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\TestResponse.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\JustFakeIt\JustFakeIt.csproj">
@@ -95,13 +108,19 @@
       <Name>JustFakeIt</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.0.0\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y /S "$(ProjectDir)TestData\*" "$(TargetDir)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/JustFakeIt.Tests/TestData/TestResponse.json
+++ b/JustFakeIt.Tests/TestData/TestResponse.json
@@ -1,0 +1,3 @@
+﻿{
+  "name": "Mick Hucknall"
+}

--- a/JustFakeIt.Tests/TestData/TestTemplate.json
+++ b/JustFakeIt.Tests/TestData/TestTemplate.json
@@ -1,0 +1,5 @@
+﻿{
+  "id": @Model.Id,
+  "userId": @Model.UserId,
+  "userEmail":  "@Model.UserEmail"
+}

--- a/JustFakeIt.Tests/packages.config
+++ b/JustFakeIt.Tests/packages.config
@@ -8,9 +8,11 @@
   <package id="Microsoft.Owin.SelfHost" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="xunit" version="2.0.0" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/JustFakeIt/FakeServer.cs
+++ b/JustFakeIt/FakeServer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Owin.Hosting;
 using Owin;
+using System.Net.Http;
 
 namespace JustFakeIt
 {
@@ -11,6 +12,7 @@ namespace JustFakeIt
     {
         public Uri BaseUri { get; private set; }
         public Expect Expect { get; protected set; }
+        public HttpClient Client { get; private set; }
 
         public IReadOnlyList<HttpRequestExpectation> CapturedRequests
         {
@@ -30,7 +32,6 @@ namespace JustFakeIt
             Expect = new Expect();
             _capturedRequests = new List<HttpRequestExpectation>();
         }
-
         public void Dispose()
         {
             if (_webApp != null)
@@ -51,6 +52,8 @@ namespace JustFakeIt
         public void Start()
         {
             _webApp = WebApp.Start(BaseUri.ToString(), app => app.Use<ProxyMiddleware>(Expect, _capturedRequests));
+            Client = new HttpClient();
+            Client.BaseAddress = BaseUri;
         }
     }
 }

--- a/JustFakeIt/HttpExpectation.cs
+++ b/JustFakeIt/HttpExpectation.cs
@@ -33,6 +33,11 @@ namespace JustFakeIt
         public void Callback(Func<HttpResponseExpectation> responseExpectationFunc)
         {
             ResponseExpectationCallback = responseExpectationFunc;
+
+        public HttpExpectation RespondsIn(TimeSpan time)
+        {
+            Response.ResponseTime = time;
+            return this;
         }
     }
 }

--- a/JustFakeIt/HttpResponseExpectation.cs
+++ b/JustFakeIt/HttpResponseExpectation.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections.Specialized;
 using System.Net;
 
 namespace JustFakeIt
@@ -8,6 +9,7 @@ namespace JustFakeIt
         public HttpStatusCode StatusCode { get; set; }
         public string ExpectedResult { get; set; }
         public WebHeaderCollection Headers { get; set; }
+        public TimeSpan ResponseTime { get; set; }
 
         public HttpResponseExpectation(HttpStatusCode expectedStatusCode, string expectedResult, NameValueCollection headers = null)
         {

--- a/JustFakeIt/JustFakeIt.csproj
+++ b/JustFakeIt/JustFakeIt.csproj
@@ -61,9 +61,18 @@
     <Reference Include="Owin">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
+    <Reference Include="RazorEngine, Version=3.9.1.0, Culture=neutral, PublicKeyToken=9ee697374c7e744a, processorArchitecture=MSIL">
+      <HintPath>..\packages\RazorEngine.3.9.1\lib\net45\RazorEngine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.0.0\lib\net45\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/JustFakeIt/JustFakeIt.nuspec
+++ b/JustFakeIt/JustFakeIt.nuspec
@@ -15,6 +15,7 @@
         <dependencies>
             <dependency id="Microsoft.Owin.SelfHost" version="3.0.1" />
             <dependency id="Newtonsoft.Json" version="7.0.1" />
+            <dependency id="RazorEngine" version="3.9.1" />
         </dependencies>
     </metadata>
     <files>

--- a/JustFakeIt/ProxyMiddleware.cs
+++ b/JustFakeIt/ProxyMiddleware.cs
@@ -128,9 +128,12 @@ namespace JustFakeIt
             if (response.Headers != null)
                 response.Headers.Add("Content-Type", new[] {"application/json"});
 
-            Task.Delay(_expect.ResponseTime).Wait();
-
+            if (httpResponseExpectation.ResponseTime != TimeSpan.Zero)
+                Task.Delay(httpResponseExpectation.ResponseTime).Wait();
+            else
+                Task.Delay(_expect.ResponseTime).Wait();
             return response.WriteAsync(expectedResults);
         }
+
     }
 }

--- a/JustFakeIt/packages.config
+++ b/JustFakeIt/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="4.0.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Razor" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Diagnostics" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
@@ -8,4 +9,5 @@
   <package id="Microsoft.Owin.SelfHost" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="RazorEngine" version="3.9.1" targetFramework="net45" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Via NuGet:
 
 Once you have the package installed into your test project, a standard wire-up will look like this.
 
-```
+```csharp
 [Fact]
 public void FakeServer_ExpectGetReturnsString_ResponseMatchesExpectation()
 {    
@@ -53,22 +53,42 @@ public void FakeServer_ExpectGetReturnsString_ResponseMatchesExpectation()
 
 Ignore parameters by replacing the value with "{ignore}"
 
-```
+```csharp
  var fakeurl = "/some-resource/{ignore}/some-resource?date={ignore}&type={ignore}";
  fakeServer.Expect.Get(fakeurl).Returns(HttpStatusCode.Accepted, expectedResult);
 ```
 
-Set a response time by setting the ResponseTime property
+Set a response time accross all endpoints by setting the `ResponseTime` property
 
-```
+```csharp
  fakeServer.Expect.ResponseTime = TimeSpan.FromSeconds(5);
 ```
 
+Set the response time for a specific endpoint with `RespondsIn()`
+
+```csharp
+ fakeServer.Expect.Get(fakeurl).Returns(HttpStatusCode.Accepted, expectedResult).RespondsIn(TimeSpan.FromSeconds(5));
+```
 Assert against captured requests
 
-```
+```csharp
  fakeServer.CapturedRequests.Count(x => x.Method == Http.Delete && x.Url == "/some-url").Should().Be(1);
 ```
+
+Return content from razor template file
+
+```csharp
+var path = "template.razor"
+fakeServer.Expect.Get(url).ReturnsFromTemplate(path, new { Id = 2343, UserId = 2343, UserEmail = "mick.hucknall@just-eat.com" })
+```
+
+Return content from file
+
+```csharp
+var path = "response.txt"
+fakeServer.Expect.Get(url).ReturnsFromFile(path)
+```
+
 
 ## Contributing
 


### PR DESCRIPTION
This PR adds support for endpoints returning from files or razor template files. 

## Razor Templating
This is useful if callers expect keys or IDs to be shared across responses from multiple endpoints. It allows templates to be reused for multiple testcases.

A relative filepath and dynamic object is required.

```csharp
fakeServer.Expect.Get(url).ReturnsFromTemplate(@"template.json.razor", new { Id = 2343 })
```

If razor isn't required the templating can be bypassed
```csharp
fakeServer.Expect.Get(url).ReturnsFromFile(@"response.txt")
```

## Endpoint specific response times
This adds support for endpoints to respond in different time.

```csharp
fakeServer.Expect.Get("/some-url").Returns(expectedResult).RespondsIn(TimeSpan.FromSeconds(5));
fakeServer.Expect.Get("/another-url").Returns(expectedResult).RespondsIn(TimeSpan.FromSeconds(50));
```

## Other stuff
Added `Client` helper property on `FakeServer` which returns a configured `HttpClient`.
```csharp
using (var fakeServer = new FakeServer()){
    fakeServer.Expect.Get("/some-url").Returns(expectedResult);
    fakeServer.Start();
    fakeserver.Client.GetAsync("/someurl");
}
```

Removed references to `WebClient` and made all tests async.

Added helper for setting response headers
```csharp
fakeServer.Expect.Get(url).Returns(expectedResult).WithHeader("Content-Language", "es")
     .WithHeader("Some-Header", "Header-McHeaderFace");
```
