### PR TITLE
Swap xUnit with Nunit

### DIFF
--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerDeleteScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerDeleteScenarios.cs
@@ -1,12 +1,12 @@
 ﻿using FluentAssertions;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerDeleteScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectDeleteReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerGetScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerGetScenarios.cs
@@ -80,7 +80,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
                 var resp = await fakeServer.Client.GetStringAsync(path);
                 var result = JsonConvert.DeserializeObject<dynamic>(resp);
 
-                Assert.Equal(expectedResult.RestaurantId, (int)result.RestaurantId);
+                Assert.That(expectedResult.RestaurantId, Is.EqualTo((int)result.RestaurantId));
             }
         }
 

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerGetScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerGetScenarios.cs
@@ -3,13 +3,13 @@ using Newtonsoft.Json;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerGetScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
@@ -26,7 +26,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetWithResponseHeadersSpecified_ResponseMatchesExpectionAndHasHeaders()
         {
             const string expectedResult = "Some String Data";
@@ -45,7 +45,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetWithQueryParametersReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
@@ -64,7 +64,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetReturnsObject_ResponseMatchesExpectation()
         {
             var expectedResult = new { RestaurantId = 1234 };
@@ -84,7 +84,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetWithMismatchingPath_Returns404()
         {
             const string expectedResult = "Some String Data";
@@ -101,7 +101,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetWithMismatchingMethod_Returns404()
         {
             const string expectedResult = "Some String Data";

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerHeaderScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerHeaderScenarios.cs
@@ -1,13 +1,13 @@
 ﻿using FluentAssertions;
 using System.Net;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerHeaderScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetWithResponseHeadersSpecifiedFluently_ResponseMatchesExpectionAndHasHeaders()
         {
             const string expectedResult = "Some String Data";
@@ -26,7 +26,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetWithRequestHeadersSpecified_WhenRequestHeadersProvided_ResponseMatchesExpection()
         {
             const string expectedResult = "Some String Data";
@@ -60,7 +60,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetWithRequestHeadersSpecified_WhenRequestHeadersNotProvided_ResponseIsBadRequest()
         {
             const string expectedResult = "X-Dummy1 header value not as expected.\r\n\tExpected: dummy1val\r\n\tProvided: other1val\r\nX-Dummy2 header was not provided.\r\n";

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerJsonComparisonScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerJsonComparisonScenarios.cs
@@ -1,13 +1,13 @@
 ﻿using FluentAssertions;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerJsonComparisonScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPostWithPartialExpectedJsonBody_ResponseMatchesExpected()
         {
             const string expectedResult = "Some String Data";
@@ -30,7 +30,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPostWithPartialExpectedJsonBodyWithNestedElements_ResponseMatchesExpected()
         {
             const string expectedResult = "Some String Data";

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerNullBodyValues.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerNullBodyValues.cs
@@ -2,13 +2,13 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerNullBodyValues
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPostWithNullReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
@@ -30,7 +30,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPostWithNullBodyAndPostWithNullBody_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
@@ -50,7 +50,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPostWithBodyAndPostWithNullBody_ResponseIsNotFound()
         {
             const string expectedResult = "Some String Data";

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerPostScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerPostScenarios.cs
@@ -2,13 +2,13 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerPostScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPostWithNoBodyReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
@@ -30,7 +30,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPostWithMismatchingBody_Returns404()
         {
             const string expectedResult = "Some String Data";

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerPutScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerPutScenarios.cs
@@ -2,13 +2,13 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerPutScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPutWithNoBodyReturnsString_ResponseMatchesExpectation()
         {
             const string expectedResult = "Some String Data";
@@ -28,7 +28,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPutWithNoBodyReturns201_Returns201()
         {
             const string expectedResult = "Some String Data";
@@ -46,7 +46,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPutWithNoBodyReturns2011_Returns201()
         {
             const string expectedResult = "Some String Data";
@@ -64,7 +64,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPutWithComplexBodyReturnsComplexObject()
         {
             const string expectedResult = "{\"Complex\":{\"Property1\":1,\"Property2\":true}}";
@@ -84,7 +84,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectPutWithObjectBodyReturns201_Returns201()
         {
             var expectedResult = new { RestaurantId = 1234 };

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerScenarios.cs
@@ -4,13 +4,13 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests
 {
     public class FakeServerScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_IgnoredParameter_Returns200()
         {
             var expectedResult = new { ResourceId = 1234 };
@@ -29,7 +29,7 @@ namespace JustFakeIt.Tests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_IgnoredParameterInRestfulpath_Returns200()
         {
             var expectedResult = new { ResourceId = 1234 };
@@ -48,7 +48,7 @@ namespace JustFakeIt.Tests
             }            
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ShouldHandleMultipleRegistrationOnSameEndPoint_WithDifferentBodies_ReturnExpectedData()
         {
             var expectedResultA = "1234";
@@ -71,7 +71,7 @@ namespace JustFakeIt.Tests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ShouldExecuteResponseExpectationCallback_ReturnExpectedData()
         {
             const string expectedResult = "Some String Data";
@@ -90,7 +90,7 @@ namespace JustFakeIt.Tests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_CapturesAllRequests()
         {
             using (var fakeServer = new FakeServer())

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerTimingScenarios.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerTimingScenarios.cs
@@ -3,13 +3,13 @@ using System;
 using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerTimingScenarios
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectAllEndpointsToHaveAFiveSecondResponseTime_ResponseTimeIsGreaterThanFiveSeconds()
         {
             var expectedResult = new { ResourceId = 1234 };
@@ -31,7 +31,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetToAnEndpointWithAFiveSecondResponseTime_ResponseTimeIsGreaterThanFiveSeconds()
         {
             var expectedResult = new { ResourceId = 1234 };

--- a/JustFakeIt.Tests/AcceptanceTests/FakeServerUsingFileContent.cs
+++ b/JustFakeIt.Tests/AcceptanceTests/FakeServerUsingFileContent.cs
@@ -3,13 +3,13 @@ using Newtonsoft.Json;
 using System;
 using System.Net;
 using System.Threading.Tasks;
-using Xunit;
+using NUnit.Framework;
 
 namespace JustFakeIt.Tests.AcceptanceTests
 {
     public class FakeServerUsingFileContent
     {
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetReturnsGeneratedTemplateFromPath_ResponseMatchesTemplate()
         {
             const string path = "/some-path";
@@ -33,7 +33,7 @@ namespace JustFakeIt.Tests.AcceptanceTests
             }
         }
 
-        [Fact]
+        [Test]
         public async Task FakeServer_ExpectGetReturnsFileContent_ResponseMatchesExpectation()
         {
             const string path = "/some-path";

--- a/JustFakeIt.Tests/JsonMatching/CompareJsonStrings.cs
+++ b/JustFakeIt.Tests/JsonMatching/CompareJsonStrings.cs
@@ -5,6 +5,7 @@ namespace JustFakeIt.Tests.JsonMatching
     public class CompareJsonStrings
     {
         private PartialJsonMatching _jsonMatcher;
+
         [SetUp]
         public void Setup()
         {

--- a/JustFakeIt.Tests/JustFakeIt.Tests.csproj
+++ b/JustFakeIt.Tests/JustFakeIt.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -74,22 +73,6 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AcceptanceTests\FakeServerDeleteScenarios.cs" />
@@ -127,12 +110,6 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
-  </Target>
   <PropertyGroup>
     <PostBuildEvent>xcopy /Y /S "$(ProjectDir)TestData\*" "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>

--- a/JustFakeIt.Tests/packages.config
+++ b/JustFakeIt.Tests/packages.config
@@ -9,11 +9,4 @@
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.5.0" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="xunit" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is a preference thing, I'm not fussed either way but since I was cleaning up the solution a bit decided to do that. Seems that we in house generally prefer xUnit so why not keep with the conventions?