### PR TITLE
Fixes issue with assigning a port that is in use

### DIFF
--- a/JustFakeIt/Ports.cs
+++ b/JustFakeIt/Ports.cs
@@ -37,6 +37,18 @@ namespace JustFakeIt
                 }
             }
 
+            var allActiveTcpListeners = ipGlobalProperties.GetActiveTcpListeners();
+            var activeTcpListeners = allActiveTcpListeners.GetEnumerator();
+
+            while (activeTcpListeners.MoveNext())
+            {
+                var ipEndPoint = (IPEndPoint) activeTcpListeners.Current;
+                if (ipEndPoint.Port == port)
+                {
+                    return false;
+                }
+            }
+
             return true;
         }
     }

--- a/JustFakeIt/Ports.cs
+++ b/JustFakeIt/Ports.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 
@@ -25,31 +26,11 @@ namespace JustFakeIt
             }
 
             var ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
-            var allActiveTcpConnections = ipGlobalProperties.GetActiveTcpConnections();
-            var activeTcpConnections = allActiveTcpConnections.GetEnumerator();
+            var activeTcpConnections = ipGlobalProperties.GetActiveTcpConnections();
+            var activeTcpListeners = ipGlobalProperties.GetActiveTcpListeners();
 
-            while (activeTcpConnections.MoveNext())
-            {
-                var tcpConnectionInformation = (TcpConnectionInformation) activeTcpConnections.Current;
-                if (tcpConnectionInformation.LocalEndPoint.Port == port)
-                {
-                    return false;
-                }
-            }
-
-            var allActiveTcpListeners = ipGlobalProperties.GetActiveTcpListeners();
-            var activeTcpListeners = allActiveTcpListeners.GetEnumerator();
-
-            while (activeTcpListeners.MoveNext())
-            {
-                var ipEndPoint = (IPEndPoint) activeTcpListeners.Current;
-                if (ipEndPoint.Port == port)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return activeTcpConnections.All(x => x.LocalEndPoint.Port != port) &&
+                   activeTcpListeners.All(x => x.Port != port);
         }
     }
 }


### PR DESCRIPTION
Related to original description here: https://github.com/justeat/JustFakeIt/issues/37
Will not fix the multi-threaded stuff, just the intermittent issue in sequentially running tests.

The problem:
`IPGlobalProperties.GetActiveTcpConnections` only returns some of the taken ports. For verification compare the output of: 
```
System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections().Select(c => c.LocalEndPoint.Port).Distinct().OrderBy(p => p).Where(p => p > 49152)
```
and 
```
System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Select(c => c.Port).Distinct().OrderBy(p => p).Where(p => p > 49152)
```
Also see: 
https://stackoverflow.com/questions/570098/in-c-how-to-check-if-a-tcp-port-is-available#comment20645614_570461